### PR TITLE
Refactor search and integrate into admin

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,17 +1,18 @@
-# All Administrate controllers inherit from this `Admin::ApplicationController`,
-# making it the ideal place to put authentication logic or other
-# before_filters.
-#
-# If you want to add pagination or other controller-level concerns,
-# you're free to overwrite the RESTful controller actions.
 module Admin
+  using Search
+
+  # Base controller for the admin panel, using the +Admin::Search+
+  # refinement to +Administrate::Search+. This controller is also
+  # responsible for authenticating admin users and setting default
+  # options, such as the records shown per page, for all admin
+  # controllers.
   class ApplicationController < Administrate::ApplicationController
     before_action :authenticate_user!
 
-    # Override this value to specify the number of elements to display at a time
-    # on index pages. Defaults to 20.
-    # def records_per_page
-    #   params[:per_page] || 20
-    # end
+    protected
+
+    def records_per_page
+      params[:per_page] || 36
+    end
   end
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -27,7 +27,7 @@ module Searchable
     end
 
     def pg_search_types
-      { tsearch: { prefix: true } }
+      Rails.application.config.search
     end
   end
 end

--- a/app/models/search/results.rb
+++ b/app/models/search/results.rb
@@ -1,0 +1,45 @@
+class Search
+  # Encapsulates the logic for finding the type of and returning actual
+  # records for any given model.
+  class Results
+    attr_reader :documents, :type
+
+    # @param [Array<PgSearch::Multisearch::Document>] all_documents
+    # @param [String] type
+    def initialize(all_documents, type)
+      @all_documents = all_documents
+      @type = type
+    end
+
+    # Collection of model objects that are represented by this results
+    # object.
+    #
+    # @return [ActiveRecord::Relation]
+    def records
+      @records ||= model.where id: ids
+    end
+
+    # Model class that the type corresponds to
+    #
+    # @return [Class]
+    def model
+      @model ||= type.constantize
+    end
+
+    # Collection of IDs used to obtain the model records.
+    #
+    # @return [Array<Integer>]
+    def ids
+      @ids ||= documents.map(&:searchable_id)
+    end
+
+    # Collection of document records filtered by type.
+    #
+    # @return [Array<PgSearch::Multisearch::Document>]
+    def documents
+      @documents ||= @all_documents.select do |document|
+        document.searchable_type == type
+      end
+    end
+  end
+end

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,4 +1,8 @@
 class Subscriber < ActiveRecord::Base
+  include Searchable
+
+  searchable name: 'A', email: 'B'
+
   validates :email, presence: true, email: true
 
   after_create :add!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,12 @@
 class User < ActiveRecord::Base
+  include Searchable
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  searchable name: 'A'
 
   # Use ActiveJob to send mails in the background
   #

--- a/app/refinements/admin/search.rb
+++ b/app/refinements/admin/search.rb
@@ -1,0 +1,11 @@
+module Admin
+  # Perform a search using PgSearch when a query is given.
+  module Search
+    refine Administrate::Search do
+      def run
+        return resource_class.all if term.blank?
+        resource_class.search term.downcase
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,5 +67,15 @@ module Brotherly
 
     # Configure CORS headers for font assets.
     config.font_assets.origin = '*'
+
+    # Global configuration for pg search
+    config.search = {
+      tsearch: {
+        prefix: true,
+        any_word: true
+      },
+      trigram: {}
+    }
+
   end
 end

--- a/config/initializers/pg_search.rb
+++ b/config/initializers/pg_search.rb
@@ -2,11 +2,5 @@
 # Configure PgSearch multi-search options
 #
 PgSearch.multisearch_options = {
-  using: {
-    tsearch: {
-      prefix: true,
-      any_word: true
-    },
-    trigram: {}
-  }
+  using: Rails.application.config.search
 }


### PR DESCRIPTION
Previously, the admin search was being handled by Administrate and using
`LIKE` queries to get the job done. It has been replaced with PgSearch's
framework for single-table postgres full-text searching. This should be
a major improvement over the SQL-compliant text queries in both speed
and reliability, and uses the same engine configuration as the frontend
search.