### PR TITLE
Fix episode autoplay when ends_at not set

### DIFF
--- a/app/decorators/episode_decorator.rb
+++ b/app/decorators/episode_decorator.rb
@@ -117,9 +117,9 @@ class EpisodeDecorator < ApplicationDecorator
     }
   end
 
-  private
-
   def autoplay?
+    return false unless model.starts_at.present?
+    return true unless model.ends_at.present?
     model.starts_at <= Time.current && model.ends_at >= Time.current
   end
 

--- a/spec/decorators/episode_decorator_spec.rb
+++ b/spec/decorators/episode_decorator_spec.rb
@@ -1,4 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe EpisodeDecorator do
+  let(:episode) { episodes :one }
+
+  context '#autoplay?' do
+    subject { episode.decorate }
+
+    it 'allows for youtube autoplay when currently streaming' do
+      episode.ends_at = 1.hour.from_now
+      expect(subject).to be_autoplay
+    end
+
+    it 'does not autoplay video after live show concludes' do
+      episode.ends_at = 1.hour.ago
+      expect(subject).not_to be_autoplay
+    end
+
+    it 'always allows autoplay when end date is blank' do
+      episode.ends_at = nil
+      expect(subject).to be_autoplay
+    end
+
+    it 'never allows autoplay when start date is blank' do
+      episode.starts_at = nil
+      expect(subject).not_to be_autoplay
+    end
+  end
 end


### PR DESCRIPTION
Fixes issue #8 wherein if ends_at is not set, an exception is thrown on
the date parsing.