### PR TITLE
Add sitemap and automatically regenerate on change.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ capybara-*.html
 /db/*.sqlite3
 /db/*.sqlite3-journal
 /public/system
+/public/sitemap*
 #**.orig
 rerun.txt
 pickle-email-*.html

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'ransack'
 gem 'kaminari'
 gem 'semver'
 gem 'aws-sdk'
+gem 'sitemap_generator'
 
 gem 'lodash-rails'
 gem 'sass', '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,6 +434,8 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    sitemap_generator (5.1.0)
+      builder
     slop (3.6.0)
     spring (1.6.1)
     spring-commands-rspec (1.0.4)
@@ -533,6 +535,7 @@ DEPENDENCIES
   sidekiq
   simple_form
   sinatra
+  sitemap_generator
   spring
   spring-commands-rspec
   spring-commands-sidekiq

--- a/app/jobs/generate_sitemap_job.rb
+++ b/app/jobs/generate_sitemap_job.rb
@@ -1,0 +1,7 @@
+class GenerateSitemapJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    require "#{Rails.root}/config/sitemap.rb"
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -2,6 +2,7 @@ class Artist < ActiveRecord::Base
   extend FriendlyId
 
   include Searchable
+  include SitemapGeneration
 
   searchable :name
   multisearchable against: [:name]

--- a/app/models/concerns/sitemap_generation.rb
+++ b/app/models/concerns/sitemap_generation.rb
@@ -1,0 +1,12 @@
+module SitemapGeneration
+  extend ActiveSupport::Concern
+
+  included do
+    after_save    :regenerate_sitemap
+    after_destroy :regenerate_sitemap
+  end
+
+  def regenerate_sitemap
+    GenerateSitemapJob.perform_later
+  end
+end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -5,6 +5,7 @@ class Episode < ActiveRecord::Base
   extend FriendlyId
 
   include Searchable
+  include SitemapGeneration
 
   has_many :performances
   has_many :artists, through: :performances
@@ -34,6 +35,7 @@ class Episode < ActiveRecord::Base
   end
 
   def future?
+    return true if starts_at.blank?
     starts_at >= Time.current
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,10 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Use the :test queue adapter to track status of background jobs and
+  # also run them inline when testing.
+  config.active_job.queue_adapter = :test
+
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,0 +1,14 @@
+# Set the host name for URL creation
+SitemapGenerator::Sitemap.default_host = "http://www.brother.ly"
+
+SitemapGenerator::Sitemap.create do
+  add episodes_path, changefreq: 'monthly'
+  Episode.all.each do |episode|
+    add episode_path(episode), lastmod: episode.updated_at, priority: 0.6, changefreq: 'never'
+  end
+
+  add artists_path, changefreq: 'monthly'
+  Artist.all.each do |artist|
+    add artist_path(artist), lastmod: artist.updated_at, priority: 0.7, changefreq: 'never'
+  end
+end

--- a/spec/jobs/generate_sitemap_job_spec.rb
+++ b/spec/jobs/generate_sitemap_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe GenerateSitemapJob, type: :job do
+  let :sitemap do
+    Rails.root.join 'public', 'sitemap.xml.gz'
+  end
+
+  it 'regenerates sitemap in the background' do
+    expect { described_class.perform_now }.not_to raise_error
+    expect(File.exist?(sitemap)).to be true
+  end
+
+  after do
+    FileUtils.rm_rf sitemap
+  end
+end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe Artist, type: :model do
   it 'represents an artist who played the event' do
     expect(subject).to be_valid
   end
+
+  it 'regenerates sitemap when saved' do
+    expect(subject.save).to be true
+    expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to include(
+      job: GenerateSitemapJob,
+      args: [],
+      queue: 'default'
+    )
+  end
 end

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe Episode, type: :model do
   it 'has a number' do
     expect(subject.number).to eq 'zero'
   end
+
+  it 'regenerates sitemap when saved' do
+    expect(subject.save).to be true
+    expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to include(
+      job: GenerateSitemapJob,
+      args: [],
+      queue: 'default'
+    )
+  end
 end


### PR DESCRIPTION
When artists or episodes data is modified in any way, regenerate the
sitemap.xml.gz file for Google and other search engines, then ping the
search engines to let them know the new sitemap is available.

Fixes issue #6.