### PR TITLE
Fix empty search params error

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,9 +1,19 @@
 class SearchesController < ApplicationController
   expose :search do
-    Search.create params[:search][:query]
+    Search.create search_params
   end
 
   def show
     respond_with search
+  end
+
+  private
+
+  def search_params
+    if params[:search]
+      params[:search][:query]
+    else
+      ''
+    end
   end
 end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Search' do
+  describe 'GET /search' do
+    it 'runs a search query when params are given' do
+      get search_path search: { query: 'test' }
+      expect(response).to have_http_status(200)
+    end
+
+    it 'runs empty search query when no params are given' do
+      get search_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
When searches are performed with no params, the app throws an error.
This will always clean the param to ensure that it's a String being
passed into `Search.create()` and no exception can be thrown.

Fixes #20