### PR TITLE
Sync db and images between local and production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ Session.vim
 /db/import
 bower_components
 node_modules
+.env.production

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,8 +60,18 @@ module Brotherly
     # Configure CORS headers for font assets.
     config.font_assets.origin = '*'
 
+    # Add Refile helpers like +attachment_url+ and
+    # +attachment_image_tag+ for rendering attachments in presenters.
     config.makeover.helpers << Refile::AttachmentHelper
 
+    # Eventbrite defaults to using bogus gateway so real calls aren't
+    # made in test or dev
     config.eventbrite_gateway = 'Eventbrite::BogusGateway'
+
+    # Shorthand for finding DB name of current env
+    config.db_name = config.database_configuration[Rails.env]['database']
+
+    # Heroku production app name
+    config.app_name = 'brotherly'
   end
 end

--- a/config/s3-cors.xml
+++ b/config/s3-cors.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <CORSRule>
+    <AllowedOrigin>http://brother.ly</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+    <AllowedHeader>Content-*</AllowedHeader>
+    <AllowedHeader>Host</AllowedHeader>
+  </CORSRule>
+  <CORSRule>
+    <AllowedOrigin>http://*.brother.ly</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+    <AllowedHeader>Content-*</AllowedHeader>
+    <AllowedHeader>Host</AllowedHeader>
+  </CORSRule>
+  <CORSRule>
+    <AllowedOrigin>http://*.brother.ly</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>POST</AllowedMethod>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+    <AllowedHeader>Authorization</AllowedHeader>
+    <AllowedHeader>Content-Type</AllowedHeader>
+    <AllowedHeader>Origin</AllowedHeader>
+  </CORSRule>
+  <CORSRule>
+    <AllowedOrigin>http://localhost:3000</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>POST</AllowedMethod>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+    <AllowedHeader>Authorization</AllowedHeader>
+    <AllowedHeader>Content-Type</AllowedHeader>
+    <AllowedHeader>Origin</AllowedHeader>
+  </CORSRule>
+</CORSConfiguration>

--- a/config/s3-policy.json
+++ b/config/s3-policy.json
@@ -1,0 +1,12 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "MakeItPublic",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::files.brother.ly/*"
+        }
+    ]
+}

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,5 +1,5 @@
 development:
-  secret_key_base: 73e29df01f4db4384a6cded4fa245639dff374a22759af9ee65866e28ca33dc03317f1caf9a6ac97fee80fa3822921eda9595c0396d2ceac387cddda5a0461bf
+  secret_key_base: <%= ENV.fetch("SECRET_KEY_BASE", "73e29df01f4db4384a6cded4fa245639dff374a22759af9ee65866e28ca33dc03317f1caf9a6ac97fee80fa3822921eda9595c0396d2ceac387cddda5a0461bf") %>
   eventbrite_api_key: 'test'
   eventbrite_client_secret: 'secret'
   eventbrite_auth_token: 'token'

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
+
 namespace :db do
-  desc 'Import database from db/import/production.dump'
-  task import: :environment do
-    database = Rails.configuration.database_configuration[Rails.env]['database']
-    sh(
-      'pg_restore',
-      '--verbose',
-      '--clean',
-      '--no-acl',
-      '--no-owner',
-      "-d#{database}",
-      'db/import/production.dump'
-    )
+  desc 'Pull down production data to the current environment'
+  task pull: %w(environment db:pull:images) do
+    config = Rails.configuration
+    sh "dropdb #{config.db_name}"
+    sh "heroku pg:pull DATABASE_URL #{config.db_name} --app #{config.app_name}"
+  end
+
+  namespace :pull do
+    task images: :environment do
+      sh "aws s3 sync s3://files.brother.ly/store #{Refile.store.directory}"
+    end
+  end
+
+  desc 'Push current database to the production environment'
+  task push: :environment do
+    sh "heroku pg:push #{config.db_name} DATABASE_URL --app #{config.app_name}"
+  end
+
+  namespace :staging do
+    desc 'Push current database to the staging environment'
+    task push: :environment do
+      staging = "#{config.app_name}-staging"
+      sh "heroku pg:push #{config.db_name} DATABASE_URL --app #{staging}"
+    end
   end
 end


### PR DESCRIPTION
A single command, `rake db:pull`, will drop the current development
database and load in all of the content from production. You must have
AWS credentials set up and the `$SECRET_KEY_BASE` pointing to production
until we can re-configure all the images to use a shared secret.