### PR TITLE
Add events calendar page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'vcr'
   gem 'webmock'
+  gem 'launchy'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,8 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     librato-metrics (1.6.1)
       aggregate (~> 0.2.2)
       faraday (~> 0.7)
@@ -488,6 +490,7 @@ DEPENDENCIES
   haml2slim
   jquery-rails
   jquery-slick-rails
+  launchy
   librato-rails
   lodash-rails
   makeover
@@ -537,4 +540,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.14.3

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,4 +1,3 @@
-doctype html
 html lang=I18n.locale xmlns:og="http://ogp.me/ns"
   head
     = render 'metadata'
@@ -22,5 +21,6 @@ html lang=I18n.locale xmlns:og="http://ogp.me/ns"
           = link_to t(:about, scope: [:titles, :pages]), about_path
           = link_to t(:upcoming, scope: [:titles, :episodes]), upcoming_episodes_path
           = link_to t(:past, scope: [:titles, :episodes]), episodes_path
+          = link_to t(:calendar, scope: [:titles, :pages]), calendar_path
     main
       = yield

--- a/app/views/pages/calendar.html.slim
+++ b/app/views/pages/calendar.html.slim
@@ -1,0 +1,5 @@
+article.page
+  header.page__title
+    h1 events calendar
+  main.page__content
+    iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=brotherlyparty%40gmail.com&amp;color=%2342104A&amp;ctz=America%2FNew_York" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,8 @@ en:
       podcast: brother.ly podcast
       upcoming: Upcoming
       past: Archives
+    pages:
+      calendar: Calendar
   subscribers:
     new:
       content: You'll be the first to know about new events and recording uploads.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   end
 
   get :about, to: 'pages#about'
+  get :calendar, to: 'pages#calendar'
 
   root to: 'episodes#show', id: '_current'
 end

--- a/spec/features/artists_spec.rb
+++ b/spec/features/artists_spec.rb
@@ -6,20 +6,20 @@ RSpec.feature 'Artists', type: :feature do
     artists :rnd
   end
 
-  scenario 'view list of artists' do
+  scenario 'can be viewed on the roster' do
     visit artists_path(format: 'html')
+
+    expect(page).to have_content(artist.name)
+
+    click_link artist.name
+
     expect(page).to have_content(artist.name)
   end
 
-  scenario 'view single artist' do
+  scenario 'can be visited directly' do
     visit artists_path(artist, format: 'html')
+
     expect(page).to have_content(artist.name)
     expect(page).to have_content(artist.description)
-  end
-
-  scenario 'view single artist from list of artists' do
-    visit artists_path(format: 'html')
-    click_link artist.name
-    expect(page).to have_content(artist.name)
   end
 end

--- a/spec/features/episodes_spec.rb
+++ b/spec/features/episodes_spec.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 require 'rails_helper'
-require 'refile/file_double'
 
 RSpec.feature 'Episodes', type: :feature do
-  let :current_episode do
-    episodes :current
+  let :episode do
+    episodes :four
   end
 
   let :video do
@@ -13,26 +12,29 @@ RSpec.feature 'Episodes', type: :feature do
     )
   end
 
-  xscenario 'home page' do
-    visit root_path
-
-    expect(page).to have_content current_episode.name
-    expect(page).to have_css '#stream'
+  before do
+    episode.update starts_at: 1.hour.ago, ends_at: 1.hour.from_now
   end
 
-  xscenario 'archive' do
+  scenario 'home page' do
+    visit root_path
+
+    expect(page).to have_content episode.name
+  end
+
+  scenario 'archive' do
     visit episodes_path
 
     expect(page).to have_content 'past episodes'
   end
 
-  xscenario 'upcoming' do
+  scenario 'upcoming' do
     visit upcoming_episodes_path
 
     expect(page).to have_content 'upcoming episodes'
   end
 
-  xscenario 'detail' do
+  scenario 'detail' do
     visit episode_path(episode)
 
     expect(page).to have_content episode.name

--- a/spec/features/pages_spec.rb
+++ b/spec/features/pages_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature 'View page', type: :feature do
+  scenario 'mission statement' do
+    visit about_path
+
+    expect(page).to have_content('About')
+  end
+
+  scenario 'events calendar' do
+    visit calendar_path
+
+    expect(page).to have_content('events calendar')
+    expect(page).to have_css('iframe')
+  end
+end

--- a/spec/features/performances_spec.rb
+++ b/spec/features/performances_spec.rb
@@ -3,14 +3,39 @@ require 'rails_helper'
 
 RSpec.feature 'Performances', type: :feature do
   let :performance do
-    performances :del_at_four
+    performances :mr_jennings_at_three
   end
 
-  scenario 'go to a performance by its episode' do
-    skip 'not yet implemented'
-    visit episodes_path(performance.episode, format: 'html')
-    click_link performance.artist.name
+  let :episode do
+    performance.episode
+  end
+
+  let :cover do
+    Refile::FileDouble.new 'cover_image', 't.jpg', content_type: 'image/jpeg'
+  end
+
+  before do
+    performance.update video_url: 'http://example.com', image: cover
+  end
+
+  scenario 'can be visited directly' do
+    visit episode_performance_path(episode, performance)
+
     expect(page).to have_content(performance.artist.name)
-    expect(page).to have_content(performance.episode.name)
+    expect(page).to have_css('video')
+  end
+
+  scenario 'can be clicked into via their episodes' do
+    visit episodes_path
+
+    click_link episode.name
+
+    expect(page).to have_content(episode.name)
+    expect(page).to have_content(performance.artist.name)
+
+    click_link performance.artist.name
+
+    expect(page).to have_content(performance.artist.name)
+    expect(page).to have_css('video')
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
+require 'refile/file_double'
 
 # Load support files
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
Embeds the Google Calendar into a page called **/calendar** on the site.

Resolves #55