### PR TITLE
Block Public Access to Staging Server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ group :test do
   gem 'capybara'
   gem 'launchy'
   gem 'poltergeist'
-  gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3.5'
   gem 'simplecov'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,10 +318,6 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
-    rails-controller-testing (1.0.1)
-      actionpack (~> 5.x)
-      actionview (~> 5.x)
-      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -543,7 +539,6 @@ DEPENDENCIES
   rack-cors
   rack-env-notifier
   rails (~> 5.2.3)
-  rails-controller-testing
   rails_12factor
   redis-rack-cache
   redis-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,10 @@ class ApplicationController < ActionController::Base
 
   # Don't render the layout when serving an Ajax request.
   layout :use_layout?
+
   DEFAULT_LAYOUT = 'application'
+  HTTP_AUTH_USERNAME = ENV['HTTP_AUTH_USERNAME']
+  HTTP_AUTH_PASSWORD = ENV['HTTP_AUTH_PASSWORD']
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -22,8 +25,19 @@ class ApplicationController < ActionController::Base
   halt Event::NotFoundError, with: :not_found
 
   before_action :cache_page, if: -> { request.get? }
+  before_action :http_authenticate!, if: :http_auth?
 
   protected
+
+  def http_auth?
+    HTTP_AUTH_USERNAME.present? && HTTP_AUTH_PASSWORD.present?
+  end
+
+  def http_authenticate!
+    authenticate_or_request_with_http_basic 'brother.ly' do |username, password|
+      username == HTTP_AUTH_USERNAME && password == HTTP_AUTH_PASSWORD
+    end
+  end
 
   def use_layout?
     request.xhr? ? false : DEFAULT_LAYOUT

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,4 +12,12 @@ class PagesController < ApplicationController
     # TODO: Article.featured
     @features = Episode.featured + Performance.featured
   end
+
+  def robots
+    @route = http_auth? ? '/' : '/admin'
+
+    respond_to do |format|
+      format.text # robots.text.erb
+    end
+  end
 end

--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: <%= @route %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
   # get "calendar/events/:id", to: 'events#show', as: :event
 
   get :oauth2callback, to: 'events#authorize_google_api'
+  get :robots, to: 'pages#robots'
 
   root to: 'pages#home'
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-# Block spiders from indexing the admin area
-User-agent: *
-Disallow: /admin

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -2,10 +2,18 @@
 
 require 'rails_helper'
 
-RSpec.describe PagesController, type: :controller do
+RSpec.describe PagesController, type: :request do
   it 'renders about page' do
-    get :about
+    get about_path
 
     expect(response).to be_successful
+  end
+
+  it 'renders robots.txt' do
+    get robots_path(format: :text)
+
+    expect(response).to be_successful
+    expect(response.body).to include('User-Agent: *')
+    expect(response.body).to include('Disallow: /admin')
   end
 end


### PR DESCRIPTION
- Add Basic HTTP auth to ApplicationController
- Remove static `robots.txt` and replace with dynamic route that
  disallows all when basic auth is provided.
- Update PagesController spec to be a request spec, and remove
  legacy controller testing gem